### PR TITLE
extend usability with new parameters

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -77,6 +77,9 @@ export interface Price {
   amount: number;
   currency: string;
   type: "budget" | "is" | "%" | "payin30days" | "payin60days";
+  fxRates: string;
+  useDuration?: number;
+  TnC?: string;
 }
 
 export interface GenericInputInstance {
@@ -103,15 +106,6 @@ export interface Transport {
 }
 
 export type TransportMethod = "air" | "sea" | "land";
-
-export interface ProductInstanceBase {
-  type: string;
-  ownerId?: string;
-  expiryDate?: number;
-  bio: boolean;
-  quantity: number;
-  price?: Price;
-}
 
 export interface FoodInstance extends ProductInstanceBase {
   category: "food";
@@ -155,15 +149,6 @@ export interface TemperatureRange {
   max: number;
 }
 
-export interface KnowHow {
-  owner: string;
-  hash: string;
-  inputs: string;
-  outputs: string;
-  licenseFee: Price;
-  note?: string | object;
-}
-
 export interface GenericImpact {
   ownerId: string;
   format: string;
@@ -184,4 +169,68 @@ export interface WaterImpact extends GenericImpact {
 export interface ID {
   registry: string;
   id: string;
+}
+
+export interface ProductInstanceBase {
+  type: string;
+  ownerId?: string;
+  expiryDate?: number;
+  bio: boolean;
+  quantity: number;
+  price?: Price;
+  attachments?: InstanceAttachments;
+}
+
+export interface KnowHow {
+  owner: string;
+  hash: string;
+  inputs: string;
+  outputs: string;
+  licenseFee: Price;
+  note?: string | object;
+  pricePerOutputQuantity?: number;
+  tenders?: Tender[];
+  outputInstanceDefaults?: ProductInstance;
+  processingSteps?: ProcessingStep[];
+}
+
+
+export interface InstanceAttachments {
+  deliveryProcess?: string;
+  resellIF?: string;
+  warranty?: Warranty;
+}
+
+export interface Warranty {
+  when: string;
+  who: string;
+  where: string;
+}
+
+export interface Tender {
+  token?: string;
+  contract?: string;
+  pricePercentage?: number;
+  conditionalDetails?: ConditionalDetails;
+  walletAddress: string;
+  status: string;
+  attachments?: string[];
+}
+
+export interface ConditionalDetails {
+  deadline: string;
+  place: string;
+}
+
+export interface ProcessingStep {
+  readCondition?: string;
+  gs1Events?: Task[];
+  hrNeeds?: Hr;
+  inputMaterialInstances?: InputInstance[];
+  inputMachineInstances?: MachineInstance[];
+}
+
+export interface Task {
+  details?: string;
+  relativeTo?: string;
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -31,7 +31,6 @@ export interface GenericProcess {
   timestamp: number;
   duration?: number;
   facility: Facility;
-  temperatureRange: TemperatureRange;
   inputInstances: (TransportedInputInstance | LocalInputInstance)[];
   impacts?: Impact[];
   price?: Price;
@@ -39,7 +38,6 @@ export interface GenericProcess {
 
 export interface PrintingProcess extends GenericProcess {
   type: "printing";
-  machineInstance: MachineInstance;
   knowHow: KnowHow;
   shape: string /* URL */;
 }
@@ -47,18 +45,15 @@ export interface PrintingProcess extends GenericProcess {
 export interface MillingProcess extends GenericProcess {
   type: "milling";
   knowHow: KnowHow;
-  machineInstance: MachineInstance;
 }
 
 export interface FreezeDryingProcess extends GenericProcess {
   type: "freezedrying";
   knowHow: KnowHow;
-  machineInstance: MachineInstance;
 }
 
 export interface BlendingProcess extends GenericProcess {
   type: "blending";
-  machineInstance: MachineInstance;
   knowHow: KnowHow;
 }
 
@@ -115,7 +110,7 @@ export interface Transport {
 export type TransportMethod = "air" | "sea" | "land";
 
 export interface FoodInstance extends ProductInstanceBase {
-  category: "food";
+  category: "biologic";
   iDs?: ID[];
   nutrients?: FallbackFoodNutrient[];
   format?: string;
@@ -124,13 +119,13 @@ export interface FoodInstance extends ProductInstanceBase {
   process?: Process;
 }
 
-export interface CartridgeInstance extends ProductInstanceBase {
-  category: "cartridge";
+export interface ObjectInstance extends ProductInstanceBase {
+  category: "object";
   grade: string;
   size: string;
 }
 
-export type ProductInstance = FoodInstance | CartridgeInstance;
+export type ProductInstance = FoodInstance | ObjectInstance;
 
 export interface FallbackFoodNutrient {
   amount: number;
@@ -142,7 +137,6 @@ export interface MachineInstance {
   ownerId: string;
   quantity: number;
   size: string;
-  hr: Hr;
   providerSDomain: string;
 }
 
@@ -213,7 +207,8 @@ export interface ProcessingStep {
   readCondition?: string;
   bizStep: string; // GS1 EPCIS2 Business step (e.g., "processing", "packing")
   hrNeeds?: Hr[];
+  temperatureRange: TemperatureRange;
   inputMaterialInstances?: InputInstance[];
-  inputMachineInstances?: MachineInstance[];
+  UsedMachineInstances?: MachineInstance[];
   notes: string;
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -78,8 +78,17 @@ export interface Price {
   currency: string;
   type: "budget" | "is" | "%" | "payin30days" | "payin60days";
   fxRates: string;
-  useDuration?: number;
-  TnC?: string;
+  useDuration: number;
+  TnC: string;
+  deliveryProcess: string;
+  resellIF: string;
+  warranty?: Warranty;
+}
+
+export interface Warranty {
+  period: string;
+  if-then: string;
+  where: string;
 }
 
 export interface GenericInputInstance {
@@ -140,6 +149,7 @@ export interface MachineInstance {
 }
 
 export interface Hr {
+  skills: string;
   tasks: string;
   assignee: string;
 }
@@ -194,43 +204,21 @@ export interface KnowHow {
   processingSteps?: ProcessingStep[];
 }
 
-
-export interface InstanceAttachments {
-  deliveryProcess?: string;
-  resellIF?: string;
-  warranty?: Warranty;
-}
-
-export interface Warranty {
-  when: string;
-  who: string;
-  where: string;
-}
-
 export interface Tender {
-  token?: string;
-  contract?: string;
-  pricePercentage?: number;
-  conditionalDetails?: ConditionalDetails;
-  walletAddress: string;
+  provider: string;
   status: string;
-  attachments?: string[];
-}
-
-export interface ConditionalDetails {
+  price: Price;
   deadline: string;
   place: string;
+  furtherConditions: string[];
+  notes: string;
 }
 
 export interface ProcessingStep {
   readCondition?: string;
-  gs1Events?: Task[];
-  hrNeeds?: Hr;
+  bizStep: string; // GS1 EPCIS2 Business step (e.g., "processing", "packing")
+  hrNeeds?: Hr[];
   inputMaterialInstances?: InputInstance[];
   inputMachineInstances?: MachineInstance[];
-}
-
-export interface Task {
-  details?: string;
-  relativeTo?: string;
+  notes: string;
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -8,9 +8,7 @@ export interface FetchError {
 
 export interface Pokedex {
   description: string;
-  contract: string;
-  token: string;
-  feedchainVersion: string;
+  ProtocolVersion: string;
   instance: ProductInstance;
 }
 
@@ -193,15 +191,12 @@ export interface ProductInstanceBase {
 
 export interface KnowHow {
   owner: string;
-  hash: string;
-  inputs: string;
-  outputs: string;
   licenseFee: Price;
-  note?: string | object;
   pricePerOutputQuantity?: number;
   tenders?: Tender[];
   outputInstanceDefaults?: ProductInstance;
   processingSteps?: ProcessingStep[];
+  notes: string | object;
 }
 
 export interface Tender {


### PR DESCRIPTION
1. price to buy, to use (duration), KnowHow used
2. instance attachments:
  1. delivery process
  2. resell IF
  3. warranty: when, who, where
3. KnowHow
  1. price to use per output quantity
    1. when bought: open for tenders? (if so: feed with tender root objects:
      1. token (if consigned: contract) or % price (royalty)
        1. Conditional details (deadline, place, etc.)
      2. wallet address
      3. status (Signed by Seller, Buyer via [OpenDocSign](https://github.com/theBojda/opendocsign) which mints its NFT)
      4. attachments (status proofs)
  2. output instance (default values)
  3. processing steps
    1. read condition: email ending with .. or bought license or anyone
    2. GS1 events as task list (some details can be missing or relative to another)
      1. HR needs
    3. input material instances
    4. input machine instances